### PR TITLE
Return genes in venn

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,7 +19,6 @@ Imports:
     foreach,
     ggnetwork,
     ggplot2,
-    ggpolypath,
     ggpubr,
     ggraph,
     ggrepel,
@@ -32,8 +31,8 @@ Imports:
     STRINGdb,
     tibble,
     tidyr
+Suggests: kimma, limma, SEARchways
 Depends: 
     R (>= 2.10)
 biocViews: 
 Remotes: BIGslu/kimma, BIGslu/SEARchways
-Suggests: kimma, limma, SEARchways

--- a/R/plot_venn_genes.R
+++ b/R/plot_venn_genes.R
@@ -36,11 +36,10 @@ plot_venn_genes <- function(model_result, model,
     stop("Must provide contrasts model when specifying contrasts.")
   }
 
-
-  #Extract results
+  #### Extract results ####
   dat <- model_result[[model]]
 
-  #List variables of interest
+  #### List variables of interest ####
   if(!is.null(variables)){
     var_all <- variables
   } else {
@@ -57,7 +56,7 @@ plot_venn_genes <- function(model_result, model,
     var_all <- var_all[!grepl("\\|", var_all)]
   }
 
-  #List contrasts of interest
+  ##### List contrasts of interest ####
   if(grepl("contrast", model)){
     if(is.null(contrasts)){
       con_filter <- dplyr::distinct(dat, contrast_ref, contrast_lvl)
@@ -69,7 +68,7 @@ plot_venn_genes <- function(model_result, model,
     }
   }
 
-  #filter data to variables/contrasts of interest
+  #### filter data to variables/contrasts of interest ####
   dat_filter <- dat %>%
     dplyr::filter(variable %in% var_all)
 
@@ -77,7 +76,8 @@ plot_venn_genes <- function(model_result, model,
     dat_filter <- dat_filter %>%
       dplyr::inner_join(con_filter, by = c("contrast_ref", "contrast_lvl"))
   }
-  #List to hold plots
+
+  #### List to hold plots ####
   venn.ls <- list()
   venn.df.ls <- list()
 

--- a/R/plot_venn_genes.R
+++ b/R/plot_venn_genes.R
@@ -111,10 +111,13 @@ plot_venn_genes <- function(model_result, model,
 
     #Plot all venns
     if(gene_tot > 0){
-    venn.ls[[as.character(fdr)]] <- ggvenn::ggvenn(venn_dat, show_percentage = FALSE,
-           text_size = 4, set_name_size = 4, stroke_size = 0.5) +
-      ggplot2::labs(x = paste("FDR <", fdr)) +
-      ggplot2::theme(axis.title.x = ggplot2::element_text())
+      venn.ls[[as.character(fdr)]] <-
+        suppressWarnings(
+          ggvenn::ggvenn(venn_dat, show_percentage = FALSE,
+                         text_size = 4, set_name_size = 4, stroke_size = 0.5) +
+            ggplot2::labs(x = paste("FDR <", fdr)) +
+            ggplot2::theme(axis.title.x = ggplot2::element_text())
+        )
     } else {
       print(paste("Zero genes significant at FDR <", fdr))
     }

--- a/R/plot_venn_genes.R
+++ b/R/plot_venn_genes.R
@@ -29,7 +29,7 @@ plot_venn_genes <- function(model_result, model,
                             return.genes=FALSE,
                             fdr.cutoff = c(0.05,0.1,0.2,0.3,0.4,0.5)){
 
-  FDR <- variable <- gene <- contrast_ref <- contrast_lvl <- NULL
+  FDR <- variable <- gene <- contrast_ref <- contrast_lvl <- temp <- NULL
 
   #common errors
   if(!is.null(contrasts) & grepl("contrast", model)){
@@ -79,7 +79,7 @@ plot_venn_genes <- function(model_result, model,
   }
   #List to hold plots
   venn.ls <- list()
-  venn.dat.ls <- list()
+  venn.df.ls <- list()
 
   for (fdr in fdr.cutoff){
     #list to hold gene vectors
@@ -124,26 +124,30 @@ plot_venn_genes <- function(model_result, model,
 
     #Save gene lists
     if(gene_tot > 0 & return.genes){
-      temp <- data.frame(gene = unique(unlist(venn_dat)))
+      all.genes <- data.frame(gene = unique(unlist(venn_dat)))
+      venn.df <- data.frame(gene = all.genes)
 
       for(v in names(venn_dat)){
+        venn.df.temp <- data.frame(gene = all.genes) %>%
+          dplyr::mutate(temp = ifelse(gene %in% venn_dat[[v]], "Y", NA))
+        colnames(venn.df.temp) <- c("gene", v)
+
         suppressMessages(
-          temp <- temp %>%
-            dplyr::mutate(!!v := ifelse(gene %in% venn_dat[[v]], "Y", NA)) %>%
-            dplyr::full_join(temp)
+          venn.df <- venn.df.temp %>%
+            dplyr::full_join(venn.df)
         )
       }
 
-      venn.dat.ls[[as.character(fdr)]] <- temp
+      venn.df.ls[[as.character(fdr)]] <- venn.df
     } else{
-      venn.dat.ls[[as.character(fdr)]] <- NULL
+      venn.df.ls[[as.character(fdr)]] <- NULL
     }
   }
 
   if(length(venn.ls) > 0){
     venn.result <- list()
     venn.result[["venn"]] <- venn.ls
-    if(return.genes){ venn.result[["gene"]] <- venn.dat.ls }
+    if(return.genes){ venn.result[["gene"]] <- venn.df.ls }
 
     return(venn.result)
   }

--- a/man/plot_venn_genes.Rd
+++ b/man/plot_venn_genes.Rd
@@ -11,6 +11,7 @@ plot_venn_genes(
   contrasts = NULL,
   intercept = FALSE,
   random = FALSE,
+  return.genes = FALSE,
   fdr.cutoff = c(0.05, 0.1, 0.2, 0.3, 0.4, 0.5)
 )
 }
@@ -27,14 +28,24 @@ plot_venn_genes(
 
 \item{random}{Logical if should include random effect variable(s). Default is FALSE}
 
+\item{return.genes}{Logical if should return data frame of genes in venns. Default is FALSE}
+
 \item{fdr.cutoff}{Numeric vector of FDR cutoffs to assess. One venn per FDR value}
 }
 \value{
-List of ggplot objects
+List with 1 each for each FDR cutoff of (1) venn diagram ggplot object and (2) data frame of genes in venn
 }
 \description{
 Venn diagrams of significant genes
 }
 \examples{
-plot_venn_genes(example_model, model = "lme", fdr.cutoff = c(0.05,0.5))
+venn.result <- plot_venn_genes(example_model, model = "lme", return.genes = TRUE,
+    fdr.cutoff = c(0.05,0.5))
+
+#plot all venn
+patchwork::wrap_plots(venn.result[["venn"]])
+#Plot 1 venn
+venn.result[["venn"]][["0.05"]]
+#see genes in intersections
+venn.result[["gene"]]
 }


### PR DESCRIPTION
**Describe the purpose of these changes**
`plot_venn_genes` now returns 2 lists

1. list of ggplot venns (as before)
2. list of data frames with genes in venn intersections

**Tests**
R packages

- [x] All code contains sufficient commenting
- [ ] `check( )` completes with no errors or warnings
- [x] If the output is changed and is used as example data in another BIGslu package, these changes do not disrupt the other package's workflow. This can be done but running `check( )` within the other package with your changes from this packages loaded by `load_all( )`
