### PR TITLE
volcano plot for contrast model. rename x.cutoff, y.cutoff

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -11,7 +11,7 @@ License: GPL (>= 3)
 Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.2.2
+RoxygenNote: 7.2.3
 Imports: 
     doParallel,
     dplyr,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: BIGpicture
 Title: Standard Plots for BIGslu
-Version: 1.0.3
+Version: 1.1.0
 Authors@R: 
     person(given = "Kim",
            family = "Dill-McFarland",

--- a/R/plot_volcano.R
+++ b/R/plot_volcano.R
@@ -15,6 +15,8 @@
 #' by x.cutoff and fdr_cutoff are labels with their HGNC symbol. If numeric, that number of most significant genes are labeled.
 #' @param genes Data frame with gene metadata for labeling points (optional). If not provided, the gene column in the model_result is used
 #' @param genes_label Character string of variable in genes to label with. Required if provide genes parameter
+#' @param x.cutoff Superseded by estimate_cutoff
+#' @param y.cutoff Superseded by fdr_cutoff
 #'
 #' @return ggplot object
 #' @export

--- a/R/plot_volcano.R
+++ b/R/plot_volcano.R
@@ -45,7 +45,7 @@ plot_volcano <- function(model_result, model, variables = NULL,
                          label = NULL, genes = NULL, genes_label = NULL,
                          x.cutoff = NULL, y.cutoff = NULL){
 
-  variable <- col.group <- lab <- facet_lab <- NULL
+  variable <- col.group <- lab <- facet_lab <- contrast_ref <- contrast_lvl <- NULL
   x.cutoff <- estimate_cutoff
   y.cutoff <- fdr_cutoff
 

--- a/R/plot_volcano.R
+++ b/R/plot_volcano.R
@@ -13,8 +13,6 @@
 #' by estimate_cutoff and fdr_cutoff are labels with their HGNC symbol. If numeric, that number of most significant genes are labeled.
 #' @param genes Data frame with gene metadata for labeling points (optional). If not provided, the gene column in the model_result is used
 #' @param genes_label Character string of variable in genes to label with. Required if provide genes parameter
-#' @param contrast_ref column name for reference contrast in model results table. Default \code{contrast_ref}
-#' @param contrast_lvl column name for comparison contrast level in model results table. Default \code{contrast_lvl}
 #' @param x.cutoff Superseded by estimate_cutoff
 #' @param y.cutoff Superseded by fdr_cutoff
 #'
@@ -39,16 +37,15 @@
 #' #Plot contrasts
 #' plot_volcano(example_model, model = "lme.contrast",
 #'              variables = "virus*asthma",
-#'              fdr_cutoff = 0.05)
+#'              fdr_cutoff = 0.05, label="all")
 
 plot_volcano <- function(model_result, model, variables = NULL,
                          x = "estimate", y = "FDR",
                          estimate_cutoff = NULL, fdr_cutoff = NULL,
                          label = NULL, genes = NULL, genes_label = NULL,
-                         contrast_ref = "contrast_ref", contrast_lvl = "contrast_lvl",
                          x.cutoff = NULL, y.cutoff = NULL){
 
-  variable <- col.group <- lab <- NULL
+  variable <- col.group <- lab <- facet_lab <- NULL
   x.cutoff <- estimate_cutoff
   y.cutoff <- fdr_cutoff
 
@@ -181,23 +178,18 @@ plot_volcano <- function(model_result, model, variables = NULL,
         dplyr::slice_min(get(y), n = label)
 
       if(grepl("contrast", model)) {
-
-        all(c(contrast_ref, contrast_lvl) %in% names(model.filter)) ||
-          stop("contrast_ref and contrast_lvl parameters should be valid column names from model results")
-
         model.filter2 <- model.filter %>%
           dplyr::filter(col.group != "NS") %>%
           dplyr::group_by_at(c(contrast_ref, contrast_lvl)) %>%
           dplyr::slice_min(get(y), n = label)
-
-        p <- p + ggplot2::facet_wrap(ggplot2::vars(contrast_ref, contrast_lvl))
       }
     }
 
     if(nrow(model.filter2) > 0 ){
       p <- p +
         ggrepel::geom_text_repel(data = model.filter2,
-                                 ggplot2::aes(label = lab), direction = "both",
+                                 ggplot2::aes(label = lab),
+                                 direction = "both",
                                  min.segment.length = ggplot2::unit(0, 'lines'),
                                  show.legend = FALSE, max.overlaps = Inf)
     }}

--- a/R/plot_volcano.R
+++ b/R/plot_volcano.R
@@ -12,7 +12,7 @@
 #' @param contrast_ref column name for reference contrast in model results table. Default \code{contrast_ref}
 #' @param contrast_lvl column name for comparison contrast level in model results table. Default \code{contrast_lvl}
 #' @param label Character or numeric. If "all", all significant genes as defined
-#' by x.cutoff and fdr_cutoff are labels with their HGNC symbol. If numeric, that number of most significant genes are labeled.
+#' by estimate_cutoff and fdr_cutoff are labels with their HGNC symbol. If numeric, that number of most significant genes are labeled.
 #' @param genes Data frame with gene metadata for labeling points (optional). If not provided, the gene column in the model_result is used
 #' @param genes_label Character string of variable in genes to label with. Required if provide genes parameter
 #' @param x.cutoff Superseded by estimate_cutoff
@@ -25,11 +25,11 @@
 #' plot_volcano(example_model, model = "lme")
 #' plot_volcano(example_model, model = "lme", variables = "virus", y = "pval")
 #' plot_volcano(example_model, model = "lme", variables = c("virus","asthma"),
-#'              x.cutoff = 0.5, fdr_cutoff = 0.05, label = 2)
+#'              estimate_cutoff = 0.5, fdr_cutoff = 0.05, label = 2)
 #' plot_volcano(example_model, model = "lme", variables = "virus",
 #'              fdr_cutoff = 0.05, label = 2)
 #' plot_volcano(example_model, model = "lme", variables = "virus",
-#'              x.cutoff = 0.5, label = 2)
+#'              estimate_cutoff = 0.5, label = 2)
 #'
 #' plot_volcano(example_model, model = "lme", variables = "virus",
 #'              fdr_cutoff = 1E-20, label = "all")

--- a/man/plot_volcano.Rd
+++ b/man/plot_volcano.Rd
@@ -10,8 +10,10 @@ plot_volcano(
   variables = NULL,
   x = "estimate",
   y = "FDR",
-  x.cutoff = NULL,
-  y.cutoff = NULL,
+  log2fc.cutoff = NULL,
+  fdr.cutoff = NULL,
+  contrast_ref = NULL,
+  contrast_lvl = NULL,
   label = NULL,
   genes = NULL,
   genes_label = NULL
@@ -28,9 +30,13 @@ plot_volcano(
 
 \item{y}{Character string of variable to plot on y-axis. Default is "FDR"}
 
-\item{x.cutoff}{Numeric.Optional x cutoff for color and/or labeling}
+\item{log2fc.cutoff}{Numeric.Optional Log2 fold change cutoff for color and/or labeling}
 
-\item{y.cutoff}{Numeric. Optional y cutoff for color and/or labeling}
+\item{fdr.cutoff}{Numeric. Optional FDR cutoff for color and/or labeling}
+
+\item{contrast_ref}{column name for reference contrast in model results table}
+
+\item{contrast_lvl}{column name for comparison contrast in model results table}
 
 \item{label}{Character or numeric. If "all", all significant genes as defined by x.cutoff and y.cutoff are labels with their HGNC symbol. If numeric, that number of most significant genes are labeled.}
 

--- a/man/plot_volcano.Rd
+++ b/man/plot_volcano.Rd
@@ -10,13 +10,13 @@ plot_volcano(
   variables = NULL,
   x = "estimate",
   y = "FDR",
-  log2fc.cutoff = NULL,
-  fdr.cutoff = NULL,
-  contrast_ref = "contrast_ref",
-  contrast_lvl = "contrast_lvl",
+  estimate_cutoff = NULL,
+  fdr_cutoff = NULL,
   label = NULL,
   genes = NULL,
-  genes_label = NULL
+  genes_label = NULL,
+  x.cutoff = NULL,
+  y.cutoff = NULL
 )
 }
 \arguments{
@@ -30,20 +30,20 @@ plot_volcano(
 
 \item{y}{Character string of variable to plot on y-axis. Default is "FDR"}
 
-\item{log2fc.cutoff}{Numeric.Optional Log2 fold change cutoff for color and/or labeling}
+\item{estimate_cutoff}{Numeric. Optional estimate (fold change or slope) cutoff for color and/or labeling}
 
-\item{fdr.cutoff}{Numeric. Optional FDR cutoff for color and/or labeling}
-
-\item{contrast_ref}{column name for reference contrast in model results table. Default \code{contrast_ref}}
-
-\item{contrast_lvl}{column name for comparison contrast level in model results table. Default \code{contrast_lvl}}
+\item{fdr_cutoff}{Numeric. Optional FDR cutoff for color and/or labeling}
 
 \item{label}{Character or numeric. If "all", all significant genes as defined
-by x.cutoff and y.cutoff are labels with their HGNC symbol. If numeric, that number of most significant genes are labeled.}
+by estimate_cutoff and fdr_cutoff are labels with their HGNC symbol. If numeric, that number of most significant genes are labeled.}
 
 \item{genes}{Data frame with gene metadata for labeling points (optional). If not provided, the gene column in the model_result is used}
 
 \item{genes_label}{Character string of variable in genes to label with. Required if provide genes parameter}
+
+\item{x.cutoff}{Superseded by estimate_cutoff}
+
+\item{y.cutoff}{Superseded by fdr_cutoff}
 }
 \value{
 ggplot object
@@ -54,16 +54,20 @@ Volcano plot of differentially expressed genes
 \examples{
 plot_volcano(example_model, model = "lme")
 plot_volcano(example_model, model = "lme", variables = "virus", y = "pval")
-plot_volcano(example_model, model = "lme", variables = c("virus","asthma"),
-             x.cutoff = 0.5, y.cutoff = 0.05, label = 2)
-plot_volcano(example_model, model = "lme", variables = "virus",
-             y.cutoff = 0.05, label = 2)
-plot_volcano(example_model, model = "lme", variables = "virus",
-             x.cutoff = 0.5, label = 2)
 
+#Select specific variables and cutoffs
+plot_volcano(example_model, model = "lme", variables = c("virus","asthma"),
+             estimate_cutoff = 0.5, fdr_cutoff = 0.05, label = 2)
+
+#Label top genes
 plot_volcano(example_model, model = "lme", variables = "virus",
-             y.cutoff = 1E-20, label = "all")
+             fdr_cutoff = 1E-20, label = "all")
 plot_volcano(example_model, model = "lme", variables = "virus",
-             y.cutoff = 1E-20, label = "all",
+             fdr_cutoff = 1E-20, label = "all",
              genes = kimma::example.voom$genes, genes_label = "hgnc_symbol")
+
+#Plot contrasts
+plot_volcano(example_model, model = "lme.contrast",
+             variables = "virus*asthma",
+             fdr_cutoff = 0.05, label="all")
 }

--- a/man/plot_volcano.Rd
+++ b/man/plot_volcano.Rd
@@ -12,8 +12,8 @@ plot_volcano(
   y = "FDR",
   log2fc.cutoff = NULL,
   fdr.cutoff = NULL,
-  contrast_ref = NULL,
-  contrast_lvl = NULL,
+  contrast_ref = "contrast_ref",
+  contrast_lvl = "contrast_lvl",
   label = NULL,
   genes = NULL,
   genes_label = NULL
@@ -34,11 +34,12 @@ plot_volcano(
 
 \item{fdr.cutoff}{Numeric. Optional FDR cutoff for color and/or labeling}
 
-\item{contrast_ref}{column name for reference contrast in model results table}
+\item{contrast_ref}{column name for reference contrast in model results table. Default \code{contrast_ref}}
 
-\item{contrast_lvl}{column name for comparison contrast in model results table}
+\item{contrast_lvl}{column name for comparison contrast level in model results table. Default \code{contrast_lvl}}
 
-\item{label}{Character or numeric. If "all", all significant genes as defined by x.cutoff and y.cutoff are labels with their HGNC symbol. If numeric, that number of most significant genes are labeled.}
+\item{label}{Character or numeric. If "all", all significant genes as defined
+by x.cutoff and y.cutoff are labels with their HGNC symbol. If numeric, that number of most significant genes are labeled.}
 
 \item{genes}{Data frame with gene metadata for labeling points (optional). If not provided, the gene column in the model_result is used}
 


### PR DESCRIPTION
- plot_volcano now accepts `contrast` model results and creates separate volcano for each pairwise comparison.
previously: `.contrast` model could be plotted, but for all pairwise comparisons collectively on one plot. Some genes could be multiplied on volcano scatter plot because of appearing as significant in more than one pairwise comparison.


- minor: renamed parameters `x.cutoff` to `log2fc.cutoff` and `y.cutoff` to `fdr.cutoff`


