### PR TITLE
Allow categorical variables in PCA heatmap

### DIFF
--- a/man/plot_pca_hm.Rd
+++ b/man/plot_pca_hm.Rd
@@ -43,7 +43,7 @@ Plot PCA Correlation Heatmap (does not calculate PCA)
 }
 \examples{
 dat_PCA <- calculate_pca(dat = kimma::example.voom, scale=TRUE)
-plot_pca_hm(dat_PCA,
-            vars = c("median_cv_coverage","lib.size"),
+plot_pca_hm(dat = dat_PCA,
+            vars = c("median_cv_coverage","lib.size", "virus"),
             scale=TRUE, flip_axes = TRUE)
 }


### PR DESCRIPTION
**Describe the purpose of these changes**

Allow categorical variables in PCA heatmap. Convert factors to numeric using pre-defined levels. Convert character to numeric using alphabetical order.

**Tests**
R packages

- [x] All code contains sufficient commenting
- [x] `check( )` completes with no errors or warnings
- [NA] If the output is changed and is used as example data in another BIGslu package, these changes do not disrupt the other package's workflow. This can be done but running `check( )` within the other package with your changes from this packages loaded by `load_all( )`
