### PR TITLE
Update plot_pca_hm.R

### DIFF
--- a/R/plot_pca_hm.R
+++ b/R/plot_pca_hm.R
@@ -79,7 +79,7 @@ plot_pca_hm <- function(dat, vars, scale = FALSE, corr_type = "pearson",
   pcs <- pca.df$PC
 
   sub_pca.dat <- pca.dat %>%
-    dplyr::select(dplyr::contains("PC"),dplyr::all_of(vars))
+    dplyr::select(dplyr::all_of(pcs),dplyr::all_of(vars))
 
   #Convert categorical to numeric
   for(var in vars){


### PR DESCRIPTION
subsetting was getting any column that contained "PC", this fix is more specific to only grab the PC and var columns

**Describe the purpose of these changes**
the part of the script to subset the data to PCs and variable list was selecting any column that contained "PC" which could lead to inclusion of unwanted variables. This adjustment specifically selects the PC and specified variable columns

**Tests**
Verify that you have completed the following tests by checking the appropriate box. All tests must pass prior to merging with the main branch.

R packages

- [x ] All code contains sufficient commenting
- [ x] `check( )` completes with no errors or warnings
- [x ] If the output is changed and is used as example data in another BIGslu package, these changes do not disrupt the other package's workflow. This can be done but running `check( )` within the other package with your changes from this packages loaded by `load_all( )`
